### PR TITLE
build and upload wheels to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Build and upload to PyPI
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels_linux:
+    name: Build wheels, manylinux
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Build wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2010_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        build-requirements: 'cython'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
+  build_wheels_macos_windows:
+    name: Build wheels, ${{ matrix.os }}, py ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [macos, windows]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install poetry
+        poetry install --extras hashes
+
+    - name: build wheel
+      run: |
+        poetry build
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Install poetry
+      shell: bash
+      run: |
+        pip install poetry
+
+    - name: Build sdist
+      run: poetry build --format sdist
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs:
+      - build_wheels_linux
+      - build_wheels_macos_windows
+      - build_sdist
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on: [push, pull_request]
 jobs:
   Tests:
 
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }}, python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,25 +28,11 @@ jobs:
     - name: Install poetry
       shell: bash
       run: |
-        curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-        python get-poetry.py --preview -y
-        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+        pip install poetry
 
     - name: Configure poetry
       shell: bash
       run: poetry config virtualenvs.in-project true
-
-    - name: Set up cache
-      uses: actions/cache@v1
-      id: cache
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Ensure cache is healthy
-      if: steps.cache.outputs.cache-hit == 'true'
-      shell: bash
-      run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
- project settings should include `pypi_password` secrets
- the secret should be the pypi api token, including `pypi-` but not trailing newlines
    - see also https://test.pypi.org/help/#invalid-auth
- also fixed a hang issue when using cache for testing in windows

The example of uploaded binary files can be viewed here: 
- https://test.pypi.org/project/fastcdc/#files

Fixed #4.