### PR TITLE
Fix chunks smaller than min_size

### DIFF
--- a/fastcdc/fastcdc_py.py
+++ b/fastcdc/fastcdc_py.py
@@ -45,8 +45,8 @@ def chunk_generator(stream, min_size, avg_size, max_size, fat, hf):
 
 def cdc_offset(data, mi, av, ma, cs, mask_s, mask_l):
     pattern = 0
-    i = mi
     size = len(data)
+    i = min(mi, size)
     barrier = min(cs, size)
     while i < barrier:
         pattern = (pattern >> 1) + GEAR[data[i]]


### PR DESCRIPTION
This issue affects chunking very small files, but also if for some reason the last chunk of a file is smaller than min_size.

Fixes #20